### PR TITLE
Prevent credentials from being overriden by SetJob

### DIFF
--- a/QuantConnect.Polygon.Tests/PolygonDataQueueHandlerCommonTests.cs
+++ b/QuantConnect.Polygon.Tests/PolygonDataQueueHandlerCommonTests.cs
@@ -111,6 +111,26 @@ namespace QuantConnect.Tests.Polygon
             Config.Set("polygon-api-key", _apiKey);
         }
 
+        [Test]
+        public void JobPacketWontOverrideCredentials()
+        {
+            var job = new LiveNodePacket
+            {
+                BrokerageData = new Dictionary<string, string>() { { "polygon-api-key", "InvalidApiKeyThatWontBeUsed" } }
+            };
+
+            // This should pick up the API key from the configuration
+            using var polygon = new PolygonDataQueueHandler();
+
+            Assert.IsFalse(polygon.IsConnected);
+
+            // This should not override the API key
+            polygon.SetJob(job);
+
+            // Since API key was not overriden, this should work
+            AssertConnection(polygon);
+        }
+
         private SubscriptionDataConfig GetSubscriptionDataConfig<T>(Symbol symbol, Resolution resolution)
         {
             return new SubscriptionDataConfig(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Prevent credentials from being overriden by SetJob. Locally the API key can be in the config which will be initialize Polygon, but then SetJob could be called without data overriding the API key with a null value. This prevents this from happening.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit test
- Manual integration with Lean

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
