### PR TITLE
Historical data when symbol was restructured (renamed)

### DIFF
--- a/QuantConnect.Polygon.Tests/PolygonDataDownloaderTests.cs
+++ b/QuantConnect.Polygon.Tests/PolygonDataDownloaderTests.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.Lean.DataSource.Polygon.Tests
 
         [TestCaseSource(nameof(IndexHistoricalInvalidDataTestCases))]
         [Explicit("This tests require a Polygon.io api key, requires internet and are long.")]
-        public void DownloadsIndexInvalidHistoricalData(Resolution resolution, TimeSpan period, TickType tickType, bool shouldBeEmpty)
+        public void DownloadsIndexInvalidHistoricalData(Resolution resolution, TimeSpan period, TickType tickType)
         {
             var data = DownloadIndexHistoryData(resolution, period, tickType);
 

--- a/QuantConnect.Polygon.Tests/PolygonHistoryTests.cs
+++ b/QuantConnect.Polygon.Tests/PolygonHistoryTests.cs
@@ -162,18 +162,17 @@ namespace QuantConnect.Lean.DataSource.Polygon.Tests
 
         [TestCaseSource(nameof(IndexHistoricalDataTestCases))]
         [Explicit("This tests require a Polygon.io api key, requires internet and are long.")]
-        public void GetsIndexHistoricalData(Resolution resolution, TimeSpan period, TickType tickType, bool shouldBeEmpty)
+        public void GetsIndexHistoricalData(Resolution resolution, TimeSpan period, TickType tickType, bool shouldBeNull)
         {
             var history = GetIndexHistory(resolution, period, tickType);
 
-            Log.Trace("Data points retrieved: " + history.Count);
-
-            if (shouldBeEmpty)
+            if (shouldBeNull)
             {
-                Assert.That(history, Is.Empty);
+                Assert.IsNull(history);
             }
             else
             {
+                Log.Trace("Data points retrieved: " + history.Count);
                 AssertHistoricalDataResults(history.Select(x => x.AllData).SelectMany(x => x).ToList(), resolution, _historyProvider.DataPointCount);
             }
         }

--- a/QuantConnect.Polygon.Tests/PolygonHistoryTests.cs
+++ b/QuantConnect.Polygon.Tests/PolygonHistoryTests.cs
@@ -186,16 +186,16 @@ namespace QuantConnect.Lean.DataSource.Polygon.Tests
             {
                 return new[]
                 {
-                    new TestCaseData(Resolution.Daily, TimeSpan.FromMinutes(5), TickType.Quote, true),
-                    new TestCaseData(Resolution.Hour, TimeSpan.FromMinutes(5), TickType.Quote, true),
-                    new TestCaseData(Resolution.Minute, TimeSpan.FromMinutes(5), TickType.Quote, true),
+                    new TestCaseData(Resolution.Daily, TimeSpan.FromMinutes(5), TickType.Quote),
+                    new TestCaseData(Resolution.Hour, TimeSpan.FromMinutes(5), TickType.Quote),
+                    new TestCaseData(Resolution.Minute, TimeSpan.FromMinutes(5), TickType.Quote),
                 };
             }
         }
 
         [TestCaseSource(nameof(IndexHistoricalInvalidDataTestCases))]
         [Explicit("This tests require a Polygon.io api key, requires internet and are long.")]
-        public void GetsIndexInvalidHistoricalData(Resolution resolution, TimeSpan period, TickType tickType, bool shouldBeEmpty)
+        public void GetsIndexInvalidHistoricalData(Resolution resolution, TimeSpan period, TickType tickType)
         {
             var history = GetIndexHistory(resolution, period, tickType);
 

--- a/QuantConnect.Polygon.Tests/PolygonSymbolMapperTests.cs
+++ b/QuantConnect.Polygon.Tests/PolygonSymbolMapperTests.cs
@@ -47,13 +47,17 @@ namespace QuantConnect.Lean.DataSource.Polygon.Tests
             Assert.That(convertedSymbol, Is.EqualTo(leanSymbol));
         }
 
-        [TestCase("O:SPY240104C00467000", SecurityType.Option, ExpectedResult = SecurityType.Equity)]
-        [TestCase("O:SPX240104C04685000", SecurityType.IndexOption, ExpectedResult = SecurityType.Index)]
-        [TestCase("O:SPXW240104C04685000", SecurityType.IndexOption, ExpectedResult = SecurityType.Index)]
-        public SecurityType ConvertsOptionSymbolWithCorrectUnderlyingSecurityType(string ticker, SecurityType optionType)
+        [TestCase("O:SPY240104C00467000", "SPY", SecurityType.Option, ExpectedResult = SecurityType.Equity)]
+        [TestCase("O:GOOGL240105C00050000", "GOOGL", SecurityType.Option, ExpectedResult = SecurityType.Equity)]
+        [TestCase("O:GOOG240105C00070000", "GOOG", SecurityType.Option, ExpectedResult = SecurityType.Equity)]
+        [TestCase("O:SPX240104C04685000", "SPX", SecurityType.IndexOption, ExpectedResult = SecurityType.Index)]
+        [TestCase("O:SPXW240104C04685000", "SPX", SecurityType.IndexOption, ExpectedResult = SecurityType.Index)]
+        public SecurityType ConvertsOptionSymbolWithCorrectUnderlyingSecurityType(string ticker, string expectedTicker, SecurityType optionType)
         {
             var mapper = new PolygonSymbolMapper();
             var symbol = mapper.GetLeanSymbol(ticker, optionType, Market.USA, new DateTime(2024, 01, 04), 400m, OptionRight.Call);
+
+            Assert.That(symbol.Underlying.Value, Is.EqualTo(expectedTicker));
 
             return symbol.Underlying.SecurityType;
         }

--- a/QuantConnect.Polygon/PolygonDataProvider.cs
+++ b/QuantConnect.Polygon/PolygonDataProvider.cs
@@ -75,8 +75,7 @@ namespace QuantConnect.Lean.DataSource.Polygon
         /// <summary>
         /// <inheritdoc cref="IMapFileProvider"/>
         /// </summary>
-        private readonly IMapFileProvider _mapFileProvider =
-            Composer.Instance.GetExportedValueByTypeName<IMapFileProvider>(Config.Get("map-file-provider", "QuantConnect.Data.Auxiliary.LocalDiskMapFileProvider"));
+        private readonly IMapFileProvider _mapFileProvider = Composer.Instance.GetPart<IMapFileProvider>();
 
         /// <summary>
         /// The time provider instance. Used for improved testability

--- a/QuantConnect.Polygon/PolygonDataProvider.cs
+++ b/QuantConnect.Polygon/PolygonDataProvider.cs
@@ -66,11 +66,11 @@ namespace QuantConnect.Lean.DataSource.Polygon
         private bool _initialized;
         private bool _disposed;
 
-        private bool _unsupportedSecurityTypeMessageLogged;
-        private bool _unsupportedTickTypeMessagedLogged;
-        private bool _unsupportedDataTypeMessageLogged;
-        private bool _potentialUnsupportedResolutionMessageLogged;
-        private bool _potentialUnsupportedTickTypeMessageLogged;
+        private volatile bool _unsupportedSecurityTypeMessageLogged;
+        private volatile bool _unsupportedTickTypeMessagedLogged;
+        private volatile bool _unsupportedDataTypeMessageLogged;
+        private volatile bool _potentialUnsupportedResolutionMessageLogged;
+        private volatile bool _potentialUnsupportedTickTypeMessageLogged;
 
         /// <summary>
         /// <inheritdoc cref="IMapFileProvider"/>
@@ -422,8 +422,8 @@ namespace QuantConnect.Lean.DataSource.Polygon
             {
                 if (!_unsupportedSecurityTypeMessageLogged)
                 {
-                    Log.Trace($"PolygonDataProvider.IsSupported(): Unsupported security type: {securityType}");
                     _unsupportedSecurityTypeMessageLogged = true;
+                    Log.Trace($"PolygonDataProvider.IsSupported(): Unsupported security type: {securityType}");
                 }
                 return false;
             }
@@ -432,8 +432,8 @@ namespace QuantConnect.Lean.DataSource.Polygon
             {
                 if (!_unsupportedTickTypeMessagedLogged)
                 {
-                    Log.Trace($"PolygonDataProvider.IsSupported(): Unsupported tick type: {tickType}");
                     _unsupportedTickTypeMessagedLogged = true;
+                    Log.Trace($"PolygonDataProvider.IsSupported(): Unsupported tick type: {tickType}");
                 }
                 return false;
             }
@@ -444,26 +444,26 @@ namespace QuantConnect.Lean.DataSource.Polygon
             {
                 if (!_unsupportedDataTypeMessageLogged)
                 {
-                    Log.Trace($"PolygonDataProvider.IsSupported(): Unsupported data type: {dataType}");
                     _unsupportedDataTypeMessageLogged = true;
+                    Log.Trace($"PolygonDataProvider.IsSupported(): Unsupported data type: {dataType}");
                 }
                 return false;
             }
 
             if (resolution < Resolution.Second && !_potentialUnsupportedResolutionMessageLogged)
             {
+                _potentialUnsupportedResolutionMessageLogged = true;
                 Log.Trace("PolygonDataProvider.IsSupported(): " +
                     $"Subscription for {securityType}-{dataType}-{tickType}-{resolution} will be attempted. " +
                     $"An Advanced Polygon.io subscription plan is required to stream tick data.");
-                _potentialUnsupportedResolutionMessageLogged = true;
             }
 
             if (tickType == TickType.Quote && !_potentialUnsupportedTickTypeMessageLogged)
             {
+                _potentialUnsupportedTickTypeMessageLogged = true;
                 Log.Trace("PolygonDataProvider.IsSupported(): " +
                     $"Subscription for {securityType}-{dataType}-{tickType}-{resolution} will be attempted. " +
                     $"An Advanced Polygon.io subscription plan is required to stream quote data.");
-                _potentialUnsupportedTickTypeMessageLogged = true;
             }
 
             return true;

--- a/QuantConnect.Polygon/PolygonDataProvider.cs
+++ b/QuantConnect.Polygon/PolygonDataProvider.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -71,6 +71,12 @@ namespace QuantConnect.Lean.DataSource.Polygon
         private bool _unsupportedDataTypeMessageLogged;
         private bool _potentialUnsupportedResolutionMessageLogged;
         private bool _potentialUnsupportedTickTypeMessageLogged;
+
+        /// <summary>
+        /// <inheritdoc cref="IMapFileProvider"/>
+        /// </summary>
+        private readonly IMapFileProvider _mapFileProvider =
+            Composer.Instance.GetExportedValueByTypeName<IMapFileProvider>(Config.Get("map-file-provider", "QuantConnect.Data.Auxiliary.LocalDiskMapFileProvider"));
 
         /// <summary>
         /// The time provider instance. Used for improved testability

--- a/QuantConnect.Polygon/PolygonHistoryProvider.cs
+++ b/QuantConnect.Polygon/PolygonHistoryProvider.cs
@@ -65,12 +65,12 @@ namespace QuantConnect.Lean.DataSource.Polygon
             {
                 var history = request.SplitHistoryRequestWithUpdatedMappedSymbol(_mapFileProvider).SelectMany(x => GetHistory(x) ?? Enumerable.Empty<BaseData>());
 
-                // TODO: extra request.
-                if (history.IsNullOrEmpty())
+                var subscription = CreateSubscription(request, history);
+                if (!subscription.MoveNext())
                 {
                     continue;
                 }
-                var subscription = CreateSubscription(request, history);
+
                 subscriptions.Add(subscription);
             }
 

--- a/QuantConnect.Polygon/PolygonHistoryProvider.cs
+++ b/QuantConnect.Polygon/PolygonHistoryProvider.cs
@@ -32,12 +32,12 @@ namespace QuantConnect.Lean.DataSource.Polygon
         /// <summary>
         /// Indicates whether a error for an invalid start time has been fired, where the start time is greater than or equal to the end time in UTC.
         /// </summary>
-        private bool _invalidStartTimeErrorFired;
+        private volatile bool _invalidStartTimeErrorFired;
 
         /// <summary>
         /// Indicates whether an error has been fired due to invalid conditions if the TickType is <seealso cref="TickType.Quote"/> and the <seealso cref="Resolution"/> is greater than one second.
         /// </summary>
-        private bool _invalidTickTypeAndResolutionErrorFired;
+        private volatile bool _invalidTickTypeAndResolutionErrorFired;
 
         /// <summary>
         /// Gets the total number of data points emitted by this history provider
@@ -101,8 +101,8 @@ namespace QuantConnect.Lean.DataSource.Polygon
             {
                 if (!_invalidTickTypeAndResolutionErrorFired)
                 {
-                    Log.Error("PolygonDataProvider.GetHistory(): Quote data above second resolution is not supported.");
                     _invalidTickTypeAndResolutionErrorFired = true;
+                    Log.Error("PolygonDataProvider.GetHistory(): Quote data above second resolution is not supported.");
                 }
                 return null;
             }
@@ -111,8 +111,8 @@ namespace QuantConnect.Lean.DataSource.Polygon
             {
                 if (!_invalidStartTimeErrorFired)
                 {
-                    Log.Error($"{nameof(PolygonDataProvider)}.{nameof(GetHistory)}:InvalidDateRange. The history request start date must precede the end date, no history returned");
                     _invalidStartTimeErrorFired = true;
+                    Log.Error($"{nameof(PolygonDataProvider)}.{nameof(GetHistory)}:InvalidDateRange. The history request start date must precede the end date, no history returned");
                 }
                 return null;
             }

--- a/QuantConnect.Polygon/PolygonHistoryProvider.cs
+++ b/QuantConnect.Polygon/PolygonHistoryProvider.cs
@@ -63,8 +63,10 @@ namespace QuantConnect.Lean.DataSource.Polygon
             var subscriptions = new List<Subscription>();
             foreach (var request in requests)
             {
-                var history = GetHistory(request);
-                if (history == null)
+                var history = request.SplitHistoryRequestWithUpdatedMappedSymbol(_mapFileProvider).SelectMany(x => GetHistory(x) ?? Enumerable.Empty<BaseData>());
+
+                // TODO: extra request.
+                if (history.IsNullOrEmpty())
                 {
                     continue;
                 }
@@ -179,7 +181,7 @@ namespace QuantConnect.Lean.DataSource.Polygon
         /// </summary>
         private IEnumerable<TradeBar> GetAggregates(HistoryRequest request)
         {
-            var ticker = _symbolMapper.GetBrokerageSymbol(request.Symbol);
+            var ticker = _symbolMapper.GetBrokerageSymbol(request.Symbol, true);
             var resolutionTimeSpan = request.Resolution.ToTimeSpan();
             // Aggregates API gets timestamps in milliseconds
             var start = Time.DateTimeToUnixTimeStampMilliseconds(request.StartTimeUtc.RoundDown(resolutionTimeSpan));

--- a/QuantConnect.Polygon/PolygonOptionChainProvider.cs
+++ b/QuantConnect.Polygon/PolygonOptionChainProvider.cs
@@ -68,7 +68,7 @@ namespace QuantConnect.Lean.DataSource.Polygon
             var optionsSecurityType = underlying.SecurityType == SecurityType.Index ? SecurityType.IndexOption : SecurityType.Option;
 
             var request = new RestRequest("/v3/reference/options/contracts", Method.GET);
-            request.AddQueryParameter("underlying_ticker", underlying.ID.Symbol);
+            request.AddQueryParameter("underlying_ticker", underlying.Value);
             request.AddQueryParameter("as_of", date.ToStringInvariant("yyyy-MM-dd"));
             request.AddQueryParameter("limit", "1000");
 

--- a/QuantConnect.Polygon/PolygonSymbolMapper.cs
+++ b/QuantConnect.Polygon/PolygonSymbolMapper.cs
@@ -130,7 +130,7 @@ namespace QuantConnect.Lean.DataSource.Polygon
                 if (!_leanSymbolsCache.TryGetValue(brokerageSymbol, out var leanSymbol))
                 {
                     var leanBaseSymbol = securityType == SecurityType.Equity ? null : GetLeanSymbol(brokerageSymbol);
-                    var underlyingSymbolStr = underlying?.ID.Symbol ?? leanBaseSymbol?.Underlying.ID.Symbol;
+                    var underlyingSymbolStr = underlying?.Value ?? leanBaseSymbol?.Underlying.Value;
 
                     switch (securityType)
                     {

--- a/QuantConnect.Polygon/PolygonSymbolMapper.cs
+++ b/QuantConnect.Polygon/PolygonSymbolMapper.cs
@@ -40,9 +40,21 @@ namespace QuantConnect.Lean.DataSource.Polygon
                 throw new ArgumentException($"Invalid symbol: {(symbol == null ? "null" : symbol.ToString())}");
             }
 
+            return GetBrokerageSymbol(symbol, false);
+        }
+
+        /// <summary>
+        /// Converts a Lean symbol instance to a brokerage symbol with updating of cached symbol collection
+        /// </summary>
+        /// <param name="symbol"></param>
+        /// <param name="isUpdateCachedSymbol"></param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        public string GetBrokerageSymbol(Symbol symbol, bool isUpdateCachedSymbol)
+        {
             lock (_locker)
             {
-                if (!_brokerageSymbolsCache.TryGetValue(symbol, out var brokerageSymbol))
+                if (!_brokerageSymbolsCache.TryGetValue(symbol, out var brokerageSymbol) || isUpdateCachedSymbol)
                 {
                     var ticker = symbol.Value.Replace(" ", "");
                     switch (symbol.SecurityType)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Currently, our data source is set up to handle some pretty ancient data, but I noticed that to get the most accurate information, it's crucial to use specific ticker names for requests.

Here's what I've done:
- I've split the HistoryRequest into smaller ones to ensure we're not fetching excessively old data.
- Fixed an issue where GetOption was making requests with the wrong symbol, ensuring we're getting the right data.
- Resolved a problem with PolygonSymbolMapper, where GetLeanSymbol was generating invalid symbols.

These changes should help improve the accuracy and reliability of our data. 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Related PR
- https://github.com/QuantConnect/Lean/pull/7826
- https://github.com/QuantConnect/Lean/pull/7845

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this pull request, you'll be able to test your algorithms in real-time (well, in backtesting) using the ancient data available. How cool is that? No more manual downloads or extra steps. Just specify the specific ticker name for your requests, and you're all set for accurate financial analysis or data processing. Let's make your testing process smoother than ever!

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Write specific test cases. 
- You can see that we did 2 request with different _ticker name_.
![image](https://github.com/QuantConnect/Lean.DataSource.Polygon/assets/45608740/76d41fa4-1e73-41f1-b325-16593b7a9c7c)

- Test cases have been executed to rigorously validate the functionality of Symbol.Value. These tests ensure the reliability and accuracy of the implementation.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
