### PR TITLE
fix(polygon-option-data): add new endpoint for polygon options

### DIFF
--- a/QuantConnect.Polygon/PolygonOptionChainProvider.cs
+++ b/QuantConnect.Polygon/PolygonOptionChainProvider.cs
@@ -66,11 +66,12 @@ namespace QuantConnect.Lean.DataSource.Polygon
 
             var underlying = symbol.SecurityType.IsOption() ? symbol.Underlying : symbol;
             var optionsSecurityType = underlying.SecurityType == SecurityType.Index ? SecurityType.IndexOption : SecurityType.Option;
+            
+            Log.Trace($"PolygonOptionChainProvider Underlying Ticker: {underlying.Value}");
 
-            var request = new RestRequest("/v3/reference/options/contracts", Method.GET);
-            request.AddQueryParameter("underlying_ticker", underlying.Value);
-            request.AddQueryParameter("as_of", date.ToStringInvariant("yyyy-MM-dd"));
-            request.AddQueryParameter("limit", "1000");
+            var request = new RestRequest($"/v3/snapshot/options/{underlying.Value}", Method.GET);
+            request.AddQueryParameter("expiration_date", date.ToStringInvariant("yyyy-MM-dd"));
+            request.AddQueryParameter("limit", "250");
 
             foreach (var contract in _restApiClient.DownloadAndParseData<OptionChainResponse>(request).SelectMany(response => response.Results))
             {

--- a/QuantConnect.Polygon/Rest/OptionContract.cs
+++ b/QuantConnect.Polygon/Rest/OptionContract.cs
@@ -52,5 +52,62 @@ namespace QuantConnect.Lean.DataSource.Polygon
         /// </summary>
         [JsonProperty("ticker")]
         public string Ticker { get; set; }
+
+        /// <summary>
+        /// The option open interest (number of open contracts)
+        /// </summary>
+        [JsonProperty("open_interest")]
+        public int OpenInterest { get; set; }
+
+        /// <summary>
+        /// The option implied volatility
+        /// </summary>
+        [JsonProperty("implied_volatility")]
+        public double ImpliedVolatility { get; set; }
+
+        /// <summary>
+        /// The option Greeks
+        /// </summary>
+        [JsonProperty("greeks")]
+        public Greeks Greeks { get; set; }
+
+        /// <summary>
+        /// The option last trade
+        /// </summary>
+        [JsonProperty("previous_close")]
+        public int Close { get; set; }
+
+        /// <summary>
+        /// The option volume
+        /// </summary>
+        [JsonProperty("volume")]
+        public int Volume { get; set; }
+    }
+
+    public class Greeks
+    {
+        /// <summary>
+        /// The option delta
+        /// </summary>
+        [JsonProperty("delta")]
+        public double Delta { get; set; }
+
+        /// <summary>
+        /// The option gamma
+        /// </summary>
+        [JsonProperty("gamma")]
+        public double Gamma { get; set; }
+        
+        /// <summary>
+        /// \The option theta
+        /// </summary>
+        [JsonProperty("theta")]
+        public double Theta { get; set; }
+
+        /// <summary>
+        /// The option vega
+        /// </summary>
+        [JsonProperty("vega")]
+        public double Vega { get; set; }
     }
 }


### PR DESCRIPTION
#### Description
- This PR has been opened to suppor the specification and reqiuirements as described in https://github.com/QuantConnect/Lean.DataSource.Polygon/issues/12
  - update polygon endpoint to get the snapshot of all options contracts for an underlying ticker.
  - update data model to support updated objects in LEAN syntax with the following data object: **open interest, greeks, Implied volatility, last pice + volume**

#### Related Issue
https://github.com/QuantConnect/Lean.DataSource.Polygon/issues/12

#### Motivation and Context
The original implementation of Polygon Options endpoint did not support parsing of data objects: **open interest, greeks, Implied volatility, last pice + volume**

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
