### PR TITLE
Feature: support `OpenInterest` 

### DIFF
--- a/QuantConnect.Polygon.Tests/PolygonDataProviderOptionsTests.cs
+++ b/QuantConnect.Polygon.Tests/PolygonDataProviderOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -145,11 +145,12 @@ namespace QuantConnect.Lean.DataSource.Polygon.Tests
                 .Select(strike =>
                 {
                     var symbol = Symbol.CreateOption(Symbols.SPY, Market.USA, OptionStyle.American, OptionRight.Call, strike,
-                        new DateTime(2024, 01, 05));
+                        new DateTime(2024, 09, 20));
                     return new[]
                     {
                         GetSubscriptionDataConfig<TradeBar>(symbol, resolution),
-                        GetSubscriptionDataConfig<QuoteBar>(symbol, resolution)
+                        GetSubscriptionDataConfig<QuoteBar>(symbol, resolution),
+                        GetSubscriptionDataConfig<OpenInterest>(symbol, resolution)
                     };
                 })
                 .SelectMany(x => x);
@@ -158,11 +159,12 @@ namespace QuantConnect.Lean.DataSource.Polygon.Tests
                 .Select(strike =>
                 {
                     var symbol = Symbol.CreateOption(Symbols.SPX, "SPXW", Market.USA, OptionStyle.American, OptionRight.Call, strike,
-                        new DateTime(2024, 01, 05));
+                        new DateTime(2024, 09, 20));
                     return new[]
                     {
                         GetSubscriptionDataConfig<TradeBar>(symbol, resolution),
-                        GetSubscriptionDataConfig<QuoteBar>(symbol, resolution)
+                        GetSubscriptionDataConfig<QuoteBar>(symbol, resolution),
+                        GetSubscriptionDataConfig<OpenInterest>(symbol, resolution)
                     };
                 })
                 .SelectMany(x => x);

--- a/QuantConnect.Polygon.Tests/PolygonOpenInterestProcessorManagerTests.cs
+++ b/QuantConnect.Polygon.Tests/PolygonOpenInterestProcessorManagerTests.cs
@@ -1,0 +1,135 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using NUnit.Framework;
+using System.Threading;
+using QuantConnect.Data;
+using QuantConnect.Tests;
+using QuantConnect.Data.Market;
+using System.Collections.Generic;
+using QuantConnect.Configuration;
+using System.Collections.Concurrent;
+using QuantConnect.Lean.Engine.DataFeeds;
+
+namespace QuantConnect.Lean.DataSource.Polygon.Tests
+{
+    public class PolygonOpenInterestProcessorManagerTests : PolygonDataProviderBaseTests
+    {
+        private readonly string _apiKey = Config.Get("polygon-api-key");
+
+        private ManualTimeProvider _timeProviderInstance = new ManualTimeProvider();
+
+        private object _locker = new object();
+
+        /// <summary>
+        /// Tests that the next run time is 9:30 AM if the current time is before 9:30 AM.
+        /// </summary>
+        [Test]
+        public void GetNextRunTime_Before930AM_Returns930AM()
+        {
+            var resetEvent = new AutoResetEvent(false);
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            var restApiClient = new PolygonRestApiClient(_apiKey);
+            var symbolMapper = new PolygonSymbolMapper();
+
+            //var subscriptionManager = new PolygonSubscriptionManager(_supportedSecurityTypes, 1,
+            //    (securityType) => new PolygonWebSocketClientWrapper(_apiKey, symbolMapper, securityType, (s) => { }));
+
+            var dataAggregator = new PolygonAggregationManager();
+
+            var configs = GetConfigs();
+
+            var subscriptionManager = new EventBasedDataQueueHandlerSubscriptionManager()
+            {
+                SubscribeImpl = (symbols, _) => { return true; },
+                UnsubscribeImpl = (symbols, _) => { return true; }
+            };
+
+            var symbolOpenInterest = new ConcurrentDictionary<Symbol, decimal>();
+            Action<BaseData> callback = (baseData) =>
+            {
+                if (baseData == null)
+                {
+                    return;
+                }
+
+                lock (_locker)
+                {
+                    symbolOpenInterest[baseData.Symbol] = baseData.Value;
+
+                    if (symbolOpenInterest.Count > 5)
+                    {
+                        resetEvent.Set();
+                    }
+                }
+            };
+
+            foreach (var config in configs)
+            {
+                subscriptionManager.Subscribe(config);
+                ProcessFeed(
+                    Subscribe(dataAggregator, config, (sender, args) => { }),
+                    cancellationTokenSource.Token,
+                    callback: callback
+                    );
+            }
+
+            var date = new DateTime(2014, 10, 7, 9, 29, 59).ConvertTo(TimeZones.NewYork, TimeZones.Utc);
+
+            _timeProviderInstance.SetCurrentTimeUtc(date);
+            var processor = new PolygonOpenInterestProcessorManager(_timeProviderInstance, restApiClient, symbolMapper, subscriptionManager, dataAggregator, GetTickTime);
+
+            resetEvent.WaitOne(TimeSpan.FromSeconds(30), cancellationTokenSource.Token);
+
+            Assert.Greater(symbolOpenInterest.Count, 0);
+
+            foreach (var (symbol, openInterest) in symbolOpenInterest)
+            {
+                Assert.Greater(openInterest, 0);
+            }
+        }
+
+        protected override List<SubscriptionDataConfig> GetConfigs(Resolution resolution = Resolution.Second)
+        {
+            var configs = new List<SubscriptionDataConfig>();
+
+            var expiryContractDate = new DateTime(2024, 09, 13);
+            var strikesAAPL = new decimal[] { 100m, 105m, 110m, 115m, 120m, 125m, 130m, 135m, 140m, 145m };
+
+            foreach (var strike in strikesAAPL)
+            {
+                var optionContract = Symbol.CreateOption(Symbols.AAPL, Market.USA, OptionStyle.American, OptionRight.Call, strike, expiryContractDate);
+                configs.Add(GetSubscriptionDataConfig<OpenInterest>(optionContract, resolution));
+            }
+
+            var strikesSPY = new decimal[] { 300m, 320m, 360m, 365m, 380m, 400m, 415m, 420m, 430m, 435m };
+
+            foreach (var strike in strikesSPY)
+            {
+                var optionContract = Symbol.CreateOption(Symbols.SPY, Market.USA, OptionStyle.American, OptionRight.Call, strike, expiryContractDate);
+                configs.Add(GetSubscriptionDataConfig<OpenInterest>(optionContract, resolution));
+            }
+
+            return configs;
+        }
+
+        private DateTime GetTickTime(Symbol symbol, DateTime utcTime) => utcTime.ConvertFromUtc(TimeZones.NewYork);
+
+        private IEnumerator<BaseData> Subscribe(PolygonAggregationManager dataAggregator, SubscriptionDataConfig dataConfig, EventHandler newDataAvailableHandler)
+            => dataAggregator.Add(dataConfig, newDataAvailableHandler);
+    }
+}

--- a/QuantConnect.Polygon.Tests/PolygonOpenInterestProcessorManagerTests.cs
+++ b/QuantConnect.Polygon.Tests/PolygonOpenInterestProcessorManagerTests.cs
@@ -47,7 +47,7 @@ namespace QuantConnect.Lean.DataSource.Polygon.Tests
         [TestCase("2024-09-16T09:30:59", true, Description = "Market: After Opening")]
         [TestCase("2024-09-16T15:28:59", true, Description = "Market: Before Closing")]
         [TestCase("2024-09-16T16:28:59", false, Description = "Market: Closed")]
-        public void GetOpenInterestAfterExchangeOpenTime(string mockDateTime, bool isShouldReturnData)
+        public void GetOpenInterestInDifferentTimeExchangeTime(string mockDateTime, bool isShouldReturnData)
         {
             var waitOneDelay = isShouldReturnData ? TimeSpan.FromSeconds(30) : TimeSpan.FromSeconds(5);
             var resetEvent = new AutoResetEvent(false);

--- a/QuantConnect.Polygon/PolygonAggregationManager.cs
+++ b/QuantConnect.Polygon/PolygonAggregationManager.cs
@@ -41,11 +41,6 @@ namespace QuantConnect.Lean.DataSource.Polygon
         /// </summary>
         protected override IDataConsolidator GetConsolidator(SubscriptionDataConfig config)
         {
-            if (config.TickType == TickType.OpenInterest)
-            {
-                throw new ArgumentException($"Unsupported subscription tick type {config.TickType}");
-            }
-
             if (_usingAggregates)
             {
                 // Starter plan only supports streaming aggregated data.

--- a/QuantConnect.Polygon/PolygonDataProvider.cs
+++ b/QuantConnect.Polygon/PolygonDataProvider.cs
@@ -298,7 +298,10 @@ namespace QuantConnect.Lean.DataSource.Polygon
             var period = TimeSpan.FromMilliseconds(aggregate.EndingTickTimestamp - aggregate.StartingTickTimestamp);
             var bar = new TradeBar(time, symbol, aggregate.Open, aggregate.High, aggregate.Low, aggregate.Close, aggregate.Volume, period);
 
-            _dataAggregator.Update(bar);
+            lock (_dataAggregator)
+            {
+                _dataAggregator.Update(bar);
+            }
         }
 
         /// <summary>
@@ -310,7 +313,10 @@ namespace QuantConnect.Lean.DataSource.Polygon
             var time = GetTickTime(symbol, trade.Timestamp);
             // TODO: Map trade.Conditions to Lean sale conditions
             var tick = new Tick(time, symbol, string.Empty, GetExchangeCode(trade.ExchangeID), trade.Size, trade.Price);
-            _dataAggregator.Update(tick);
+            lock (_dataAggregator)
+            {
+                _dataAggregator.Update(tick);
+            }
         }
 
         /// <summary>
@@ -324,7 +330,10 @@ namespace QuantConnect.Lean.DataSource.Polygon
             // Note: Polygon's quotes have bid/ask exchange IDs, but Lean only has one exchange per tick. We'll use the bid exchange.
             var tick = new Tick(time, symbol, string.Empty, GetExchangeCode(quote.BidExchangeID),
                 quote.BidSize, quote.BidPrice, quote.AskSize, quote.AskPrice);
-            _dataAggregator.Update(tick);
+            lock (_dataAggregator)
+            {
+                _dataAggregator.Update(tick);
+            }
         }
 
         /// <summary>

--- a/QuantConnect.Polygon/PolygonDataProvider.cs
+++ b/QuantConnect.Polygon/PolygonDataProvider.cs
@@ -432,7 +432,7 @@ namespace QuantConnect.Lean.DataSource.Polygon
 
             if (!dataType.IsAssignableFrom(typeof(TradeBar)) &&
                 !dataType.IsAssignableFrom(typeof(QuoteBar)) &&
-!dataType.IsAssignableFrom(typeof(OpenInterest)) &&
+                !dataType.IsAssignableFrom(typeof(OpenInterest)) &&
                 !dataType.IsAssignableFrom(typeof(Tick)))
             {
                 if (!_unsupportedDataTypeMessageLogged)

--- a/QuantConnect.Polygon/PolygonDataProvider.cs
+++ b/QuantConnect.Polygon/PolygonDataProvider.cs
@@ -430,18 +430,9 @@ namespace QuantConnect.Lean.DataSource.Polygon
                 return false;
             }
 
-            if (tickType == TickType.OpenInterest)
-            {
-                if (!_unsupportedTickTypeMessagedLogged)
-                {
-                    _unsupportedTickTypeMessagedLogged = true;
-                    Log.Trace($"PolygonDataProvider.IsSupported(): Unsupported tick type: {tickType}");
-                }
-                return false;
-            }
-
             if (!dataType.IsAssignableFrom(typeof(TradeBar)) &&
                 !dataType.IsAssignableFrom(typeof(QuoteBar)) &&
+!dataType.IsAssignableFrom(typeof(OpenInterest)) &&
                 !dataType.IsAssignableFrom(typeof(Tick)))
             {
                 if (!_unsupportedDataTypeMessageLogged)

--- a/QuantConnect.Polygon/PolygonDataProvider.cs
+++ b/QuantConnect.Polygon/PolygonDataProvider.cs
@@ -158,6 +158,8 @@ namespace QuantConnect.Lean.DataSource.Polygon
                     maxSubscriptionsPerWebSocket,
                     (securityType) => new PolygonWebSocketClientWrapper(_apiKey, _symbolMapper, securityType, OnMessage));
             }
+            var openInterestManager = new PolygonOpenInterestProcessorManager(TimeProvider, RestApiClient, _symbolMapper, _subscriptionManager, _dataAggregator, GetTickTime);
+            openInterestManager.ScheduleNextRun();
         }
 
         #region IDataQueueHandler implementation

--- a/QuantConnect.Polygon/PolygonHistoryProvider.cs
+++ b/QuantConnect.Polygon/PolygonHistoryProvider.cs
@@ -95,6 +95,16 @@ namespace QuantConnect.Lean.DataSource.Polygon
                 return null;
             }
 
+            if (request.TickType == TickType.OpenInterest)
+            {
+                if (!_unsupportedTickTypeMessagedLogged)
+                {
+                    _unsupportedTickTypeMessagedLogged = true;
+                    Log.Trace($"PolygonDataProvider.GetHistory(): Unsupported tick type: {TickType.OpenInterest}");
+                }
+                return null;
+            }
+
             // Quote data can only be fetched from Polygon from their Quote Tick endpoint,
             // which would be too slow for anything above second resolution or long time spans.
             if (request.TickType == TickType.Quote && request.Resolution > Resolution.Second)

--- a/QuantConnect.Polygon/PolygonOpenInterestProcessorManager.cs
+++ b/QuantConnect.Polygon/PolygonOpenInterestProcessorManager.cs
@@ -1,0 +1,174 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using NodaTime;
+using QuantConnect.Data.Market;
+using QuantConnect.Lean.DataSource.Polygon.Rest;
+using RestSharp;
+
+namespace QuantConnect.Lean.DataSource.Polygon
+{
+    public class PolygonOpenInterestProcessorManager : IDisposable
+    {
+        /// <summary>
+        /// Timer used to schedule the execution of the <see cref="ProcessOpenInterest"/> method.
+        /// </summary>
+        private Timer? _openInterestScheduler;
+
+        /// <summary>
+        /// Gets the time zone for New York City, USA. This is a daylight savings time zone.
+        /// </summary>
+        private static readonly DateTimeZone _nyTimeZone = TimeZones.NewYork;
+
+        /// <summary>
+        /// The time provider instance.
+        /// </summary>
+        private readonly ITimeProvider _timeProvider;
+
+        /// <summary>
+        /// The <see cref="PolygonRestApiClient"/> REST API client instance.
+        /// </summary>
+        private readonly PolygonRestApiClient _polygonRestApiClient;
+
+        /// <summary>
+        /// Provides the mapping between Lean symbols and Polygon.io symbols.
+        /// </summary>
+        private readonly PolygonSymbolMapper _symbolMapper;
+
+        /// <summary>
+        /// Subscription manager to handle the subscriptions for the Polygon data queue handler.
+        /// </summary>
+        private readonly PolygonSubscriptionManager _polygonSubscriptionManager;
+
+        /// <summary>
+        /// Aggregates Polygon.io trade bars into same or higher resolution bars
+        /// </summary>
+        private readonly PolygonAggregationManager _dataAggregator;
+
+        /// <summary>
+        /// A delegate that retrieves the tick time for a given symbol and UTC timestamp.
+        /// </summary>
+        /// <param name="symbol">The financial instrument or symbol for which the tick time is being retrieved.</param>
+        /// <param name="utcTime">The UTC time for which the tick time is being calculated.</param>
+        /// <returns>
+        /// The tick time as a <see cref="DateTime"/> for the given <paramref name="symbol"/> and <paramref name="utcTime"/>.
+        /// </returns>
+        private readonly Func<Symbol, DateTime, DateTime> _getTickTime;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="timeProvider"></param>
+        /// <param name="polygonRestApiClient"></param>
+        /// <param name="symbolMapper"></param>
+        /// <param name="polygonSubscriptionManager"></param>
+        /// <param name="dataAggregator"></param>
+        /// <param name="getTickTime"></param>
+        public PolygonOpenInterestProcessorManager(ITimeProvider timeProvider, PolygonRestApiClient polygonRestApiClient, PolygonSymbolMapper symbolMapper,
+            PolygonSubscriptionManager polygonSubscriptionManager, PolygonAggregationManager dataAggregator, Func<Symbol, DateTime, DateTime> getTickTime)
+        {
+            _timeProvider = timeProvider;
+            _symbolMapper = symbolMapper;
+            _dataAggregator = dataAggregator;
+            _polygonRestApiClient = polygonRestApiClient;
+            _polygonSubscriptionManager = polygonSubscriptionManager;
+            _getTickTime = getTickTime;
+            
+            ScheduleNextRun();
+        }
+
+        /// <summary>
+        /// Schedules the next execution of the <see cref="ProcessOpenInterest"/> method
+        /// based on the current time in New York (Eastern Time).
+        /// </summary>
+        private void ScheduleNextRun()
+        {
+            var now = _timeProvider.GetUtcNow().ConvertFromUtc(_nyTimeZone);
+            var nextRunTime = GetNextRunTime(now);
+
+            TimeSpan delay = nextRunTime - now;
+
+            // Initialize the timer to run the method at the calculated delay
+            _openInterestScheduler = new Timer(RunProcessOpenInterest, null, delay, Timeout.InfiniteTimeSpan);
+        }
+
+        /// <summary>
+        /// Runs the <see cref="ProcessOpenInterest"/> method and reschedules the next execution.
+        /// </summary>
+        private void RunProcessOpenInterest(object? _)
+        {
+            var subscribedSymbol = _polygonSubscriptionManager.GetSubscribedSymbols().ToList();
+
+            ProcessOpenInterest(subscribedSymbol);
+
+            // Reschedule for the next execution at either 9:30 AM or 3:30 PM
+            ScheduleNextRun();
+        }
+
+        public void ProcessOpenInterest(IReadOnlyCollection<Symbol> subscribedSymbols)
+        {
+            var subscribedBrokerageSymbols = subscribedSymbols.Select(x => _symbolMapper.GetBrokerageSymbol(x));
+            //var symbols = dataConfigs.Select(x => x.Symbol).ToList();
+            //var subscribedSymbols = symbols.Select(x => _symbolMapper.GetBrokerageSymbol(x)).Distinct();
+
+            var restRequest = new RestRequest($"v3/snapshot?ticker.any_of={string.Join(',', subscribedBrokerageSymbols)}", Method.GET);
+            restRequest.AddQueryParameter("limit", "250");
+
+            foreach (var universalSnapshot in _polygonRestApiClient.DownloadAndParseData<UniversalSnapshotResponse>(restRequest).SelectMany(response => response.Results))
+            {
+                var leanSymbol = _symbolMapper.GetLeanSymbol(universalSnapshot.Ticker!);
+                var time = _getTickTime(leanSymbol, DateTime.UtcNow);
+                var openInterest = new OpenInterest(time, leanSymbol, universalSnapshot.OpenInterest);
+
+                _dataAggregator.Update(openInterest);
+            }
+        }
+
+        /// <summary>
+        /// Calculates the next run time (9:30 AM or 3:30 PM New York Time) based on the current time.
+        /// </summary>
+        /// <param name="currentTime">The current time in the New York time zone.</param>
+        /// <returns>The next execution time at either 9:30 AM or 3:30 PM.</returns>
+        private DateTime GetNextRunTime(DateTime currentTime)
+        {
+            DateTime today930AM = currentTime.Date.AddHours(9).AddMinutes(30);
+            DateTime today330PM = currentTime.Date.AddHours(15).AddMinutes(30);
+
+            if (currentTime < today930AM)
+            {
+                // If it's before 9:30 AM, schedule the next run for 9:30 AM today
+                return today930AM;
+            }
+            else if (currentTime >= today930AM && currentTime < today330PM)
+            {
+                // If it's between 9:30 AM and 3:30 PM, schedule the next run for 3:30 PM today
+                return today330PM;
+            }
+            else
+            {
+                // If it's after 3:30 PM, schedule the next run for 9:30 AM tomorrow
+                return today930AM.AddDays(1);
+            }
+        }
+
+        /// <summary>
+        /// Disposes the resources used by the <see cref="OpenInterestProcessor"/>.
+        /// </summary>
+        public void Dispose()
+        {
+            _openInterestScheduler?.Dispose();
+        }
+    }
+}

--- a/QuantConnect.Polygon/PolygonOpenInterestProcessorManager.cs
+++ b/QuantConnect.Polygon/PolygonOpenInterestProcessorManager.cs
@@ -101,8 +101,14 @@ namespace QuantConnect.Lean.DataSource.Polygon
 
             TimeSpan delay = nextRunTime - now;
 
-            // Initialize the timer to run the method at the calculated delay
-            _openInterestScheduler = new Timer(RunProcessOpenInterest, null, delay, Timeout.InfiniteTimeSpan);
+            if (_openInterestScheduler != null)
+            {
+                _openInterestScheduler.Change(delay, Timeout.InfiniteTimeSpan);
+            }
+            else
+            {
+                _openInterestScheduler = new Timer(RunProcessOpenInterest, null, delay, Timeout.InfiniteTimeSpan);
+            }
         }
 
         /// <summary>

--- a/QuantConnect.Polygon/PolygonOpenInterestProcessorManager.cs
+++ b/QuantConnect.Polygon/PolygonOpenInterestProcessorManager.cs
@@ -155,9 +155,10 @@ namespace QuantConnect.Lean.DataSource.Polygon
                 var leanSymbol = _symbolMapper.GetLeanSymbol(universalSnapshot.Ticker!);
                 var time = _getTickTime(leanSymbol, nowUtc);
 
+                var openInterestTick = new Tick(time, leanSymbol, universalSnapshot.OpenInterest);
                 lock (_dataAggregator)
                 {
-                    _dataAggregator.Update(new Tick(time, leanSymbol, universalSnapshot.OpenInterest));
+                    _dataAggregator.Update(openInterestTick);
                 }
             }
         }

--- a/QuantConnect.Polygon/PolygonOpenInterestProcessorManager.cs
+++ b/QuantConnect.Polygon/PolygonOpenInterestProcessorManager.cs
@@ -123,8 +123,6 @@ namespace QuantConnect.Lean.DataSource.Polygon
         private void ProcessOpenInterest(IReadOnlyCollection<Symbol> subscribedSymbols)
         {
             var subscribedBrokerageSymbols = subscribedSymbols.Select(x => _symbolMapper.GetBrokerageSymbol(x));
-            //var symbols = dataConfigs.Select(x => x.Symbol).ToList();
-            //var subscribedSymbols = symbols.Select(x => _symbolMapper.GetBrokerageSymbol(x)).Distinct();
 
             var restRequest = new RestRequest($"v3/snapshot?ticker.any_of={string.Join(',', subscribedBrokerageSymbols)}", Method.GET);
             restRequest.AddQueryParameter("limit", "250");

--- a/QuantConnect.Polygon/PolygonSubscriptionManager.cs
+++ b/QuantConnect.Polygon/PolygonSubscriptionManager.cs
@@ -113,6 +113,12 @@ namespace QuantConnect.Lean.DataSource.Polygon
         /// <param name="tickType">Type of tick data</param>
         protected override bool Subscribe(IEnumerable<Symbol> symbols, TickType tickType)
         {
+            if (tickType == TickType.OpenInterest)
+            {
+                // Skip subscribing to OpenInterest and consider using PolygonOpenInterestProcessorManager instead, as Polygon doesn't support live updating of OpenInterest.
+                return true;
+            }
+
             Log.Trace($"PolygonSubscriptionManager.Subscribe(): {string.Join(",", symbols.Select(x => x.Value))}");
 
             foreach (var symbol in symbols)

--- a/QuantConnect.Polygon/Rest/UniversalSnapshot.cs
+++ b/QuantConnect.Polygon/Rest/UniversalSnapshot.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Newtonsoft.Json;
+
+namespace QuantConnect.Lean.DataSource.Polygon.Rest
+{
+    public class UniversalSnapshot
+    {
+        /// <summary>
+        /// The details for this contract.
+        /// </summary>
+        [JsonProperty("details")]
+        public OptionContract? OptionContract { get; set; }
+
+        /// <summary>
+        /// The quantity of this contract held at the end of the last trading day.
+        /// </summary>
+        [JsonProperty("open_interest")]
+        public decimal OpenInterest { get; set; }
+
+        /// <summary>
+        /// The ticker symbol for the asset.
+        /// </summary>
+        [JsonProperty("ticker")]
+        public string? Ticker { get; set; }
+
+        /// <summary>
+        /// The asset class for this ticker.
+        /// </summary>
+        [JsonProperty("type")]
+        public string? Type { get; set; }
+    }
+}

--- a/QuantConnect.Polygon/Rest/UniversalSnapshotResponse.cs
+++ b/QuantConnect.Polygon/Rest/UniversalSnapshotResponse.cs
@@ -1,0 +1,21 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace QuantConnect.Lean.DataSource.Polygon.Rest
+{
+    public class UniversalSnapshotResponse : BaseResultsResponse<UniversalSnapshot>
+    {
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Develop an independent class, `PolygonOpenInterestProcessorManager`, to retrieve the current `OpenInterest` snapshot for a _subscribed symbols_ and return it to **Lean** to update the Securities property `OpenInterest`.
- We need to make two calls per day: one at [**9:31 AM/New York time zone**] when the market opens, and another at [**3:29 PM/New York time zone**] before the market closes.
- Add an overloading method `ProcessFeed()` to improve the quality of subscription testing.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #12 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Helps the user to get the actual Open Interest update for their algorithm so they can handle it in an appropriate way.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- The `PolygonOpenInterestProcessorManager` has an `ITimeProvider` as a constructor parameter, which helps to test execution with a mock of time.
- When we have tested it using Lean, we can manually change the variable `nextRunTimeNewYork` in the function `ScheduleNextRun()`.
- Also, if we want to retrieve data outside of Exchange working hours, please pay attention to the variable 'nowNewYork' in the function 'RunProcessOpenInterest'.
- Explore test `class PolygonOpenInterestProcessorManagerTests`

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
