### PR TITLE
Fix: exception message when subscribe use specific SecurityType

### DIFF
--- a/QuantConnect.Polygon/PolygonDataProvider.cs
+++ b/QuantConnect.Polygon/PolygonDataProvider.cs
@@ -210,7 +210,19 @@ namespace QuantConnect.Lean.DataSource.Polygon
 
             Log.Trace($"PolygonDataProvider.Subscribe(): Subscribing to {dataConfig.Symbol} | {dataConfig.TickType}");
 
-            _subscriptionManager.Subscribe(dataConfig);
+            if (_subscriptionManager.GetWebSocket(dataConfig.SecurityType) == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                _subscriptionManager.Subscribe(dataConfig);
+            }
+            catch (PolygonAuthenticationException)
+            {
+                return null;
+            }
 
             _dataAggregator.SetUsingAggregates(_subscriptionManager.UsingAggregates);
             var enumerator = _dataAggregator.Add(dataConfig, newDataAvailableHandler);

--- a/QuantConnect.Polygon/PolygonSubscriptionManager.cs
+++ b/QuantConnect.Polygon/PolygonSubscriptionManager.cs
@@ -192,7 +192,7 @@ namespace QuantConnect.Lean.DataSource.Polygon
                 var message = jsonMessage["message"]?.ToString() ?? string.Empty;
                 if (status.Contains("auth_failed", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    Log.Trace($"PolygonSubscriptionManager.ConnectWebSocket(): Failed authentication: {message}.");
+                    Log.Error($"PolygonSubscriptionManager.ConnectWebSocket(): Failed authentication: {message}.");
                     failedAuthenticationEvent.Set();
                 }
                 else if (status.Contains("auth_success", StringComparison.InvariantCultureIgnoreCase))
@@ -215,7 +215,7 @@ namespace QuantConnect.Lean.DataSource.Polygon
 
             if (result == 0)
             {
-                throw new PolygonAuthenticationException("Failed to authenticate websocket. Make sure your API key is valid and has the right permissions.");
+                throw new PolygonAuthenticationException($"WebSocket authentication failed for security types: {string.Join(", ", webSocket.SupportedSecurityTypes)}. Make sure your API key is valid and has the right permissions.");
             }
 
             Log.Trace($"PolygonSubscriptionManager.ConnectWebSocket(): Successfully connected websocket.");

--- a/QuantConnect.Polygon/PolygonSubscriptionManager.cs
+++ b/QuantConnect.Polygon/PolygonSubscriptionManager.cs
@@ -213,7 +213,7 @@ namespace QuantConnect.Lean.DataSource.Polygon
             webSocket.Message += callback;
             webSocket.Connect();
 
-            var result = WaitHandle.WaitAny(new[] { failedAuthenticationEvent, authenticatedEvent }, TimeSpan.FromSeconds(60));
+            var result = WaitHandle.WaitAny(new[]{ failedAuthenticationEvent, authenticatedEvent  }, TimeSpan.FromSeconds(60));
             webSocket.Message -= callback;
 
             if (result == WaitHandle.WaitTimeout)

--- a/QuantConnect.Polygon/PolygonSubscriptionManager.cs
+++ b/QuantConnect.Polygon/PolygonSubscriptionManager.cs
@@ -213,7 +213,7 @@ namespace QuantConnect.Lean.DataSource.Polygon
             webSocket.Message += callback;
             webSocket.Connect();
 
-            var result = WaitHandle.WaitAny(new[]{ failedAuthenticationEvent, authenticatedEvent  }, TimeSpan.FromSeconds(60));
+            var result = WaitHandle.WaitAny(new[] { failedAuthenticationEvent, authenticatedEvent }, TimeSpan.FromSeconds(60));
             webSocket.Message -= callback;
 
             if (result == WaitHandle.WaitTimeout)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
1. Change the color of the exception message;
2. Added `SecurityType` in the exception message.
3. return `null` enumerator in `Subscribe(...)` 

![image](https://github.com/user-attachments/assets/2e9b1d87-b3a3-4487-8915-b1735c37b812)



#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #21

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Make exception messages more user-friendly and informative.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/a

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Try subscribing to SecurityTypes that your polygon key doesn't have permission for.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
