### PR TITLE
Fix: `BaseUrl` for Index's business license type

### DIFF
--- a/QuantConnect.Polygon.Tests/PolygonDataProviderFairMarketValueTests.cs
+++ b/QuantConnect.Polygon.Tests/PolygonDataProviderFairMarketValueTests.cs
@@ -24,6 +24,7 @@ using QuantConnect.Logging;
 using QuantConnect.Data.Market;
 using QuantConnect.Configuration;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
 
@@ -59,14 +60,14 @@ namespace QuantConnect.Lean.DataSource.Polygon.Tests
 
             var configs = GetConfigs(resolution);
 
-            var receivedData = new Dictionary<Symbol, List<BaseData>>();
+            var receivedData = new ConcurrentDictionary<Symbol, List<BaseData>>();
 
             var resetEvent = new AutoResetEvent(false);
             var receivedAllData = default(bool);
 
-            foreach (var config in configs)
+            foreach (var config in configs.OrderByDescending(x => x.TickType == TickType.OpenInterest))
             {
-                receivedData[config.Symbol] = [];
+                receivedData.TryAdd(config.Symbol, []);
 
                 polygon.Subscribe(config, (sender, args) =>
                 {

--- a/QuantConnect.Polygon.Tests/PolygonDataProviderFairMarketValueTests.cs
+++ b/QuantConnect.Polygon.Tests/PolygonDataProviderFairMarketValueTests.cs
@@ -39,10 +39,10 @@ namespace QuantConnect.Lean.DataSource.Polygon.Tests
             {
                 Symbols.AAPL,
                 Symbols.MSFT,
-                Symbol.CreateOption(Symbols.AAPL, Symbols.AAPL.ID.Market, SecurityType.Option.DefaultOptionStyle(), OptionRight.Call, 227.5m, new(2025, 08, 29)),
-                Symbol.CreateOption(Symbols.MSFT, Symbols.MSFT.ID.Market, SecurityType.Option.DefaultOptionStyle(), OptionRight.Call, 502.5m, new(2025, 08, 29)),
-                //Symbols.SPX,
-                Symbol.CreateOption(Symbols.SPX, "SPXW", Symbols.SPX.ID.Market, SecurityType.IndexOption.DefaultOptionStyle(), OptionRight.Call, 6485m, new(2025, 08, 29))
+                Symbol.CreateOption(Symbols.AAPL, Symbols.AAPL.ID.Market, SecurityType.Option.DefaultOptionStyle(), OptionRight.Call, 227.5m, new(2025, 09, 05)),
+                Symbol.CreateOption(Symbols.MSFT, Symbols.MSFT.ID.Market, SecurityType.Option.DefaultOptionStyle(), OptionRight.Call, 502.5m, new(2025, 09, 05)),
+                Symbols.SPX,
+                Symbol.CreateOption(Symbols.SPX, "SPXW", Symbols.SPX.ID.Market, SecurityType.IndexOption.DefaultOptionStyle(), OptionRight.Call, 6470m, new(2025, 09, 05))
             };
 
             return [.. symbols.SelectMany(symbol => GetSubscriptionDataConfigs(symbol, resolution))];

--- a/QuantConnect.Polygon/PolygonWebSocketClientWrapper.cs
+++ b/QuantConnect.Polygon/PolygonWebSocketClientWrapper.cs
@@ -98,6 +98,7 @@ namespace QuantConnect.Lean.DataSource.Polygon
             var baseUrl = licenseType switch
             {
                 LicenseType.Individual => "wss://socket.polygon.io",
+                LicenseType.Business when securityType == SecurityType.Index => "wss://socket.polygon.io",
                 LicenseType.Business =>"wss://business.polygon.io",
                 _ => throw new NotSupportedException($"{nameof(PolygonWebSocketClientWrapper)}: Unsupported license type '{licenseType}'. Expected either 'Individual' or 'Business'.")
             };


### PR DESCRIPTION
#### Description
Input configs:
```
"polygon-api-key": "XXX"
"polygon-license-type": "Business",
```

🔴 The subscription on `wss://business.polygon.io/indices` URL returns an error message:
```
The server returned status code '404' when status code '101' was expected.
```
🟢 We need to use the `wss://socket.polygon.io` to subscribe to index value updates - [docs](https://polygon.io/docs/websocket/indices/value)
```
WebSocketClientWrapper.HandleConnection(wss://socket.polygon.io/indices): Connecting...
WebSocketClientWrapper.OnOpen(): Connection opened (IsOpen:True, State:Open): wss://socket.polygon.io/indices
PolygonWebSocketClientWrapper.OnOpen(): Index - connection open
PolygonWebSocketClientWrapper.OnMessage.JSON: [{"ev":"status","status":"connected","message":"Connected Successfully"}]

PolygonWebSocketClientWrapper.Subscribe.JSON: {"action":"subscribe","params":"V.I:SPX"}
PolygonWebSocketClientWrapper.OnMessage.JSON: [{"ev":"status","status":"success","message":"subscribed to: V.I:SPX"}]
```

#### Related PRs
- https://github.com/QuantConnect/Lean.DataSource.Polygon/pull/35

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
